### PR TITLE
Fixed signup subscription failure

### DIFF
--- a/payments/views.py
+++ b/payments/views.py
@@ -85,8 +85,10 @@ def create_sub(request, *args):
 
     sub, created = Subscription.objects.get_or_create(customer=customer)
     sub.stripe_subscription_id = subscription.id
-    sub.end_billing_period = subscription_end_date()
     sub.active = True
+    sub.save()
+
+    sub.end_billing_period = subscription_end_date()
     sub.save()
 
 


### PR DESCRIPTION
Fixed subscription failure during signup caused by setting the payment end period before the sub it was in the db